### PR TITLE
Fix and refactor Backup job store and delete methods

### DIFF
--- a/app/Http/Controllers/BackupJobController.php
+++ b/app/Http/Controllers/BackupJobController.php
@@ -86,7 +86,30 @@ class BackupJobController extends Controller
 
     public function destroy(BackupJob $backupJob)
     {
+        $relativePath = trim($backupJob->backup_path);
+        $fullPath = storage_path('app/' . $relativePath);
+
+        $fileWasThere = file_exists($fullPath); // ← Check BEFORE deleting
+        if ($fileWasThere) 
+        {
+            if (!@unlink($fullPath)) {
+                Log::error("Failed to delete backup file: {$fullPath}");
+
+                return response()->json([
+                    'message'   => 'Failed to delete the backup file from disk.',
+                    'file_path' => $relativePath,
+                ], 500);
+            }
+        } else {
+            Log::warning("Backup file not found during delete: {$fullPath}");
+        }
+
         $backupJob->delete();
-        return response('The Backup Job has been deleted');
+
+        return response()->json([
+            'message' => $fileWasThere
+                ? 'Backup file and record deleted successfully.'
+                : 'Backup record deleted. File was already missing.',
+        ]);
     }
 }

--- a/app/Http/Controllers/BackupJobController.php
+++ b/app/Http/Controllers/BackupJobController.php
@@ -9,6 +9,8 @@ use App\Services\DatabaseBackupService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Config;
 use App\Http\Resources\BackupJobResource;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
 
 class BackupJobController extends Controller
 {
@@ -55,7 +57,7 @@ class BackupJobController extends Controller
 
         // Run backup via backup service
         try {
-            $result = DatabaseBackupService::backup($connectionName,'/app/backups');
+            $result = DatabaseBackupService::backup($connectionName,'backups');
            
             // Update job record with success
             $backupJob->update([

--- a/app/Services/DatabaseBackupService.php
+++ b/app/Services/DatabaseBackupService.php
@@ -15,9 +15,9 @@ class DatabaseBackupService
         // File name format like: client_db_backup_20250613_162510.sql
         $filename = "{$config['database']}_backup_" . date('Ymd_His') . ".sql";
         $relativePath = "{$outputPath}/{$filename}";
-        $fullPath = storage_path($relativePath);
+        $fullPath = storage_path('app/' . $relativePath);
 
-        // Build mysqldump command
+        // Build mysqldump command to output to stdout (no `> file`)
         $command = sprintf(
             'mysqldump --user=%s --password=%s --host=%s --port=%s %s > %s 2>&1',
             escapeshellarg($config['username']),
@@ -28,20 +28,20 @@ class DatabaseBackupService
             escapeshellarg($fullPath)
         );
 
-        // Execute it ($command)
-        $result = null;
+         // Run command
         $output = [];
+        $result = null;
         exec($command, $output, $result);
 
-        // wait 100 ms.to fully writing the file to avoid getting wronge size
-        usleep(100000); 
+        // Check if file was created and has content(avvoid getting size = 0)
+        $fileSize = file_exists($fullPath) ? filesize($fullPath) : 0;
 
         // Success
-        if ($result === 0 && file_exists($fullPath)) {
+        if ($result === 0 && $fileSize > 0) {
             return [
-                'status'    => true,
-                'file_path' => $fullPath,
-                'file_size' => filesize($fullPath),
+                'status'          => true,
+                'file_path'       => $relativePath,
+                'file_size'       => $fileSize,
             ];
         }
 


### PR DESCRIPTION
- Fix store method on backupJob controller by passing path (backups) instead of (app/backups). and edit Datab
aseBackupService class by make it return the relative path (backups/SimpleCRM_backup_20250618_141152.sql) instead of the full path(/home/ghofran/Documents/workspace/SideProjects/db-backup-utility/storage/app/backups/SimpleCRM_backup_20250617_215913.sql). and checking the file size before return back to the controller to avoid getting size=0

- Refactor: early delete method was deleting backupJob's record only from the db. now it deletes the record and the dump file related to that record with approprate response message 