### PR TITLE
Refactor backup/store operations by implementing SOLID

### DIFF
--- a/app/Factories/DatabaseAdapterFactory.php
+++ b/app/Factories/DatabaseAdapterFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Factories;
+
+use App\Models\DatabaseConnection;
+use App\Services\Contracts\DatabaseAdapterInterface;
+use App\Services\Adapters\MySQLDatabaseAdapter;
+use InvalidArgumentException;
+
+class DatabaseAdapterFactory
+{
+    public function make(DatabaseConnection $connection): DatabaseAdapterInterface
+    {
+        return match (strtolower($connection->type)) {
+            'mysql' => new MySQLDatabaseAdapter($connection),
+            default => throw new InvalidArgumentException("Unsupported database type: {$connection->type}")
+        };
+    }
+}

--- a/app/Http/Controllers/BackupJobController.php
+++ b/app/Http/Controllers/BackupJobController.php
@@ -12,6 +12,8 @@ use App\Exceptions\DatabaseConnectionException;
 use App\Exceptions\BackupFailedException;
 use Symfony\Component\HttpFoundation\Response;
 use App\Traits\ApiResponseTrait;
+use App\Models\DatabaseConnection;
+use App\Factories\DatabaseAdapterFactory;
 
 class BackupJobController extends Controller
 {
@@ -30,6 +32,8 @@ class BackupJobController extends Controller
     {
         $input = $request->validated();
 
+        $db_connection = DatabaseConnection::findOrFail($input['db_id']);
+
         $backupJob = BackupJob::create([
             'database_connection_id' => $input['db_id'],
             'status'                 => 'pending',
@@ -41,23 +45,29 @@ class BackupJobController extends Controller
 
         // Run backup via backup service
         try {
-            $service = new DatabaseBackupService();
-            $backupResult = $service->backup($input['db_id'],'backups');
+            // Use factory to resolve correct adapter
+            $adapterFactory = new DatabaseAdapterFactory();
+            $adapter = $adapterFactory->make($db_connection);
+
+            // Run backup
+            $backupService = new DatabaseBackupService($adapter);
+            $backupResult = $backupService->backup($db_connection, 'backups');// pass the absolute path 
            
             $backupJob->update([ // Update job record with success
                 'status'       => 'completed',
-                'backup_path'  => $backupResult['file_path'],
+                'backup_path'  => $backupResult['relative_path'],
                 'file_size'    => $backupResult['file_size'],
                 'completed_at' => now()
                 ]);
 
             // log after backup operation success:
-            BackupLoggerService::logSuccess($backupJob, $backupResult['file_path'], $backupResult['file_size']);
+            BackupLoggerService::logSuccess($backupJob, $backupResult['relative_path'], $backupResult['file_size']);
+           
             } catch (DatabaseConnectionException $e) {
                 return $this->errorResponse(
                     'Database connection failed',
                     [
-                        'type' => $e->getType(),
+                        'type'    => $e->getType(),
                         'message' => $e->getMessage()
                     ],
                     Response::HTTP_UNPROCESSABLE_ENTITY
@@ -73,13 +83,13 @@ class BackupJobController extends Controller
                 BackupLoggerService::logFailure($backupJob, $e);
 
                 return $this->errorResponse(
-                'Backup failed',
-                [
-                    'type'    => $e->getType(),
-                    'message' => $e->getMessage(),
-                ],
-                Response::HTTP_INTERNAL_SERVER_ERROR
-            );
+                    'Backup failed',
+                    [
+                        'type'    => $e->getType(),
+                        'message' => $e->getMessage(),
+                    ],
+                    Response::HTTP_INTERNAL_SERVER_ERROR
+                );
             }
 
         return $this->successResponse(

--- a/app/Http/Controllers/RestoreBackupController.php
+++ b/app/Http/Controllers/RestoreBackupController.php
@@ -5,20 +5,32 @@ namespace App\Http\Controllers;
 use App\Http\Requests\RestoreBackupRequest;
 use App\Services\RestoreBackupService;
 use App\Services\ConfigService;
-use Illuminate\Http\JsonResponse;
-
+use App\Models\DatabaseConnection;
+use App\Factories\DatabaseAdapterFactory;
+use App\Traits\ApiResponseTrait;
 
 class RestoreBackupController extends Controller
 {
+    use ApiResponseTrait;
 
     function restoreBackup(RestoreBackupRequest $request)
     {
         $validated = $request->validated();
-    
-        $service = new RestoreBackupService(new ConfigService());
-        $result = $service->restore($validated);
+        $connection = DatabaseConnection::findOrFail($validated['db_id']);
 
-        return response()->json([$result['data'], $result['status']]);
+        // Use factory to resolve correct adapter
+        $adapterFactory = new DatabaseAdapterFactory();
+        $adapter = $adapterFactory->make($connection);
+
+        // Run backup
+        $restore_service = new RestoreBackupService(new ConfigService(), $adapter);
+        $restore_result = $restore_service->restore($validated);
+
+        return $this->successResponse(
+            null,
+            $restore_result['message'],
+            200,
+        );
     }
 
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Services\Contracts\DatabaseAdapterInterface;
+use App\Services\Adapters\MySQLDatabaseAdapter;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -11,7 +13,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(DatabaseAdapterInterface::class, MySQLDatabaseAdapter::class);
     }
 
     /**

--- a/app/Services/Adapters/MySQLDatabaseAdapter.php
+++ b/app/Services/Adapters/MySQLDatabaseAdapter.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Services\Adapters;
+
+use App\Services\Contracts\DatabaseAdapterInterface;
+use App\Models\DatabaseConnection;
+use App\Exceptions\BackupFailedException;
+use Exception;
+
+class MySQLDatabaseAdapter implements DatabaseAdapterInterface
+{
+
+    protected DatabaseConnection $connection;
+
+    public function __construct(DatabaseConnection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function backup(string $absolutePath)
+    {
+        // Ensure the backup directory exists
+        $dir = dirname($absolutePath);
+        if (!file_exists($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $command = sprintf(
+            'mysqldump -u%s -p%s -h%s -P%s %s 2>&1 > %s',
+            escapeshellarg($this->connection->username),
+            escapeshellarg($this->connection->password),
+            escapeshellarg($this->connection->host),
+            $this->connection->port ?? 3306,
+            $this->connection->db_name,
+            escapeshellarg($absolutePath)
+            );
+
+       // Run command
+        try {
+        exec($command, $output, $exitCode);
+        $outputText = implode("\n", $output);
+
+        if ($exitCode !== 0) {
+            // Clean up empty file
+            if (file_exists($absolutePath) && filesize($absolutePath) === 0) {
+                @unlink($absolutePath);
+            }
+
+            if (stripos($outputText, 'access denied') !== false) {
+                throw new BackupFailedException('Invalid database credentials.', 'invalid_credentials');
+            }
+            if (stripos($outputText, 'command not found') !== false) {
+                throw new BackupFailedException('mysqldump command not found.', 'mysqldump_missing');
+            }
+            if (stripos($outputText, 'permission denied') !== false) {
+                throw new BackupFailedException('Permission denied while writing backup file.', 'permission_denied');
+            }
+            if (stripos($outputText, 'no space left on device') !== false) {
+                throw new BackupFailedException('Insufficient disk space for backup.', 'disk_full');
+            }
+            if (stripos($outputText, 'timed out') !== false) {
+                throw new BackupFailedException('Database backup operation timed out.', 'timeout');
+            }
+            if (stripos($outputText, 'unknown mysql server host') !== false ||
+                stripos($outputText, "can't connect to mysql server") !== false) {
+                throw new BackupFailedException('Cannot connect to MySQL server.', 'host_unreachable');
+            }
+
+            // Unknown issue
+            throw new BackupFailedException("Backup failed with unknown error: $outputText", 'unknown');
+        }
+
+        return true;
+
+        } catch (BackupFailedException $e) {
+            // rethrow for upper-level service to handle
+            throw $e;
+        }
+    }
+
+    public function restore($filePath)
+    {
+        // Check if backup file exists
+        if (!file_exists($filePath)) {
+            throw new BackupFailedException("Backup file not found at: $filePath", 'file_not_found');
+        }
+
+        // Build the restore command
+        $command = sprintf(
+            'mysql -u%s -p%s -h%s -P%s %s < %s',
+            escapeshellarg($this->connection->username),
+            escapeshellarg($this->connection->password),
+            escapeshellarg($this->connection->host),
+            $this->connection->port ?? 3306,
+            escapeshellarg($this->connection->db_name),
+            escapeshellarg($filePath)
+        );
+
+        exec($command . ' 2>&1', $output, $exitCode);
+        $outputText = implode("\n", $output);
+
+        if ($exitCode !== 0) {
+            // Check for common errors and throw typed exceptions if you want
+            if (stripos($outputText, 'access denied') !== false) {
+                throw new BackupFailedException('Invalid database credentials.', 'invalid_credentials');
+            }
+            if (stripos($outputText, 'permission denied') !== false) {
+                throw new BackupFailedException('Permission denied while restoring database.', 'permission_denied');
+            }
+            if (stripos($outputText, 'unknown mysql server host') !== false ||
+                stripos($outputText, "can't connect to mysql server") !== false) {
+                throw new BackupFailedException('Cannot connect to MySQL server.', 'host_unreachable');
+            }
+
+            // Unknown error fallback
+            throw new BackupFailedException("Restore failed: $outputText", 'unknown');
+        }
+
+        return true;
+    }
+
+    public function testConnection(): bool
+    {
+        $cmd = sprintf(
+            'mysql -u%s -p%s -h%s -P%s -e "USE %s;"',
+            escapeshellarg($this->connection->username),
+            escapeshellarg($this->connection->password),
+            escapeshellarg($this->connection->host),
+            $this->connection->port ?? 3306,
+            escapeshellarg($this->connection->db_name)
+        );
+
+        exec($cmd . ' 2>&1', $output, $exitCode);
+
+        if ($exitCode !== 0) {
+            throw new \Exception(implode("\n", $output)); // this is key
+        }
+
+        return true;
+    }
+}
+

--- a/app/Services/Contracts/DatabaseAdapterInterface.php
+++ b/app/Services/Contracts/DatabaseAdapterInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Services\Contracts;
+
+interface DatabaseAdapterInterface
+{
+    public function backup(String $outputPath);
+
+    public function testConnection();
+
+    public function restore(string $filePath);
+
+}

--- a/app/Services/DatabaseBackupService.php
+++ b/app/Services/DatabaseBackupService.php
@@ -2,91 +2,62 @@
 namespace App\Services;
 
 use App\Exceptions\BackupFailedException;
+use App\Exceptions\DatabaseConnectionException;
 use App\Services\TestDatabaseConnectionService;
-use App\Traits\ApiResponseTrait;
-use Illuminate\Support\Facades\Log;
+use App\Models\DatabaseConnection;
+use App\Services\Contracts\DatabaseAdapterInterface;
 
 class DatabaseBackupService
 {
-    use ApiResponseTrait;
 
-    public function backup($db_id, $outputPath)
+    protected DatabaseAdapterInterface $adapter;
+
+    public function __construct(DatabaseAdapterInterface $adapter)
     {
-        // Firstly test DB Connection
-        $result = TestDatabaseConnectionService::createDynamicConnection($db_id);
-        $connectionName = $result['connectionName'];
+        $this->adapter = $adapter;
+    }
 
-        // Get connection config from memory
-        $config = config("database.connections.{$connectionName}");
+    public function backup(DatabaseConnection $connection, string $outputPath): array
+    {
+        try {
+            $this->adapter->testConnection();
+        } catch (\Exception $e) {
+            $message = $e->getMessage();
 
-        // File name format like: client_db_backup_20250613_162510.sql
-        $filename = "{$config['database']}_backup_" . date('Ymd_His') . ".sql";
-        $relativePath = "{$outputPath}/{$filename}";
-        $fullPath = storage_path('app/' . $relativePath);
-
-        // Build mysqldump command to output to stdout (no `> file`)
-        $command = sprintf(
-            'mysqldump --user=%s --password=%s --host=%s --port=%s %s 2>&1 > %s',
-            escapeshellarg($config['username']),
-            escapeshellarg($config['password']),
-            escapeshellarg($config['host']),
-            escapeshellarg($config['port'] ?? '3306'),
-            escapeshellarg($config['database']),
-            escapeshellarg($fullPath)
-        );
-
-       // Run command
-        $output = [];
-        $result = 0;
-        exec($command, $output, $result);
-
-        $outputText = implode("\n", $output);
-
-        // Analyze common error cases
-        if ($result !== 0 ) 
-        {
-            // On failure:
-            Log::error('CLI Backup failed', [
-                'db_id'   => $db_id,
-                // 'error'            => $e->getMessage(),
-                // 'trace'            => $e->getTraceAsString()
-            ]);
-
-            if (stripos($outputText, 'access denied') !== false) {
-                throw new BackupFailedException('Invalid database credentials.', 'invalid_credentials');
+            if (str_contains($message, 'Access denied')) {
+                throw new DatabaseConnectionException('Invalid database credentials.', 'invalid_credentials');
             }
-            if (stripos($outputText, 'sh: 1: mysqldump_fake: not found') !== false ||  stripos($outputText, 'command not found') !== false) {
-                throw new BackupFailedException('mysqldump command not found.', 'mysqldump_missing');
+            if (str_contains($message, 'Unknown database')) {
+                throw new DatabaseConnectionException('Database does not exist.', 'database_missing');
             }
-            if (stripos($outputText, 'permission denied') !== false) {
-                throw new BackupFailedException('Permission denied while writing backup file.', 'permission_denied');
+            if (str_contains($message, 'Connection refused') || str_contains($message, 'php_network_getaddresses')) {
+                throw new DatabaseConnectionException('Database host unreachable.', 'host_unreachable');
             }
-            if (stripos($outputText, 'no space left on device') !== false) {
-                throw new BackupFailedException('Insufficient disk space for backup.', 'disk_full');
+            if (str_contains($message, 'timed out')) {
+                throw new DatabaseConnectionException('Connection timed out.', 'connection_timeout');
             }
-            if (stripos($outputText, 'timed out') !== false) {
-                throw new BackupFailedException('Database backup operation timed out.', 'timeout');
-            }
-            if (stripos($outputText, 'unknown mysql server host') !== false) {
-                throw new BackupFailedException('Unknown MySQL server host.', 'host_unreachable');
-            }
-            if (stripos($outputText, "can't connect to mysql server") !== false) {
-                throw new BackupFailedException('Cannot connect to MySQL server on the specified host.', 'host_unreachable');
-            }
-            throw new BackupFailedException("Backup failed: $outputText", 'unknown');
         }
 
-        // Check if file was created and has content(avvoid getting size = 0)
-        $fileSize = file_exists($fullPath) ? filesize($fullPath) : 0;
+        // Generate filename and paths
+        $connectionName = 'temp_' . uniqid();
+        $filename = $connection->db_name.'_'.$connectionName . '_backup_' . now()->format('Ymd_His') . '.sql';
 
-        // Success
-        if ($result === 0 && $fileSize > 0) {
-            return [
-                'status'          => true,
-                'file_path'       => $relativePath,
-                'file_size'       => $fileSize,
-            ];
+        $relativePath = trim($outputPath, '/') . '/' . $filename;
+        $absolutePath = storage_path('app/' . $relativePath);
+
+        $success = $this->adapter->backup($absolutePath);
+
+        if (! $success) {
+            throw new BackupFailedException("Backup operation failed.");
         }
+
+        $fileSize = file_exists($absolutePath) ? filesize($absolutePath) : null;
+
+        return [
+            'relative_path' => $relativePath,
+            'absolute_path' => $absolutePath,
+            'file_size'     => $fileSize,
+        ];
     }
 
     public function backupUsingProfile($config,$outputPath)

--- a/app/Services/RestoreBackupService.php
+++ b/app/Services/RestoreBackupService.php
@@ -2,102 +2,57 @@
 namespace App\Services;
 
 use App\Services\ConfigService;
-use App\Models\DatabaseConnection;
-use Symfony\Component\HttpFoundation\Response;
+use App\Exceptions\DatabaseConnectionException;
+use App\Exceptions\BackupFailedException;
+use App\Services\Contracts\DatabaseAdapterInterface;
 
 class RestoreBackupService
 {
     protected ConfigService $configService;
+    protected DatabaseAdapterInterface $adapter;
 
-    public function __construct(ConfigService $configService)
+    public function __construct(ConfigService $configService,DatabaseAdapterInterface $adapter)
     {
         $this->configService = $configService;
+        $this->adapter = $adapter;
     }
 
-    public function restore($validated) 
+    public function restore($validated)
     {
+        try { // Test DB connection before restore
+            $this->adapter->testConnection();
+        } catch (\Exception $e) {
+            $message = $e->getMessage();
+
+            if (str_contains($message, 'Access denied')) {
+                throw new DatabaseConnectionException('Invalid database credentials.', 'invalid_credentials');
+            }
+            if (str_contains($message, 'Unknown database')) {
+                throw new DatabaseConnectionException('Database does not exist.', 'database_missing');
+            }
+            if (str_contains($message, 'Connection refused') || str_contains($message, 'php_network_getaddresses')) {
+                throw new DatabaseConnectionException('Database host unreachable.', 'host_unreachable');
+            }
+            if (str_contains($message, 'timed out')) {
+                throw new DatabaseConnectionException('Connection timed out.', 'connection_timeout');
+            }
+        }
+
         $file = $validated['file'];
 
-        // ✅ Normalize file path
         if (!str_starts_with($file, '/') && !preg_match('/^[A-Z]:\\\\/', $file)) {
-            $file = base_path($file);
+            $file = storage_path('app/' . $file);
         }
 
         if (!file_exists($file)) {
-            return [
-                'status' => 404,
-                'data' => ['message' => "Backup file not found: $file"],
-            ];
+            throw new BackupFailedException("Backup file not found: $file", 'file_not_found');
         }
 
-        $config = null;
-
-        if (! empty($validated['db_profile'])) {  // Load DB  from config file (via profile)
-            $profile = $validated['db_profile'];
-            $profiles = $this->configService->loadProfiles();
-
-            if (!isset($profiles[$profile])) {
-                return [
-                    'status' => 404,
-                    'data' => ['message' => "Profile '$profile' not found."],
-                ];
-            }
-
-            $config = $profiles[$profile];
-
-        }elseif ($validated['db_id']) { // Load DB  from Database (via id)
-            $db_id = $validated['db_id'];
-            $connection = DatabaseConnection::find($db_id);
-
-            if (!$connection) {
-                return [
-                    'status' => 404,
-                    'data' => ['message' => "Database ID '$db_id' not found."],
-                ];
-            }
-
-            $config = [
-                'driver'   => $connection->type,
-                'host'     => $connection->host,
-                'port'     => $connection->port,
-                'database' => $connection->db_name,
-                'username' => $connection->username,
-                'password' => $connection->password,
-            ];
-        }
-
-        // ✅ Validate driver
-        if (!isset($config['driver']) || $config['driver'] !== 'mysql') {
-            return [
-                'status' => 422,
-                'data' => ['message' => 'Only MySQL is supported for restore at this time.'],
-            ];
-        }
-
-        // ✅ Build restore command
-        $command = sprintf(
-            'mysql -h%s -P%s -u%s -p%s %s < %s',
-            escapeshellarg($config['host']),
-            escapeshellarg($config['port'] ?? '3306'),
-            escapeshellarg($config['username']),
-            escapeshellarg($config['password']),
-            escapeshellarg($config['database']),
-            escapeshellarg($file)
-        );
-
-        $exitCode = null;
-        system($command, $exitCode);
-
-        if ($exitCode === 0) {
-            return [
-                'status' => 200,
-                'data' => ['message' => 'Database restored successfully.'],
-            ];
-        }
+        // Run restore (delegated to adapter)
+        $this->adapter->restore($file);
 
         return [
-            'status' => 500,
-            'data' => ['message' => "Restore failed with exit code: $exitCode"],
-        ];        
+            'message' => 'Database restored successfully.',
+        ];
     }
 }


### PR DESCRIPTION
 Refactor backup/store (via API) operations by implement SOLID principles :

- Created DatabaseAdapterInterface with 3 method: backup, store and testConnection and implemented those methods in MySQLDatabaseAdapter to handle backup operations for mysql databases.

- Explicitly bind DatabaseAdapterInterface to a concrete implementation(MySQLDatabaseAdapter) using the service container in register() in AppServiceProvider class.

- Bulit DatabaseAdapterFactory to resolve the correct adapter (mysql or later on postgres or what ever DB type).