### PR TITLE
support postgres DB by implemeting backup and restore methods. and us…

### DIFF
--- a/app/Factories/DatabaseAdapterFactory.php
+++ b/app/Factories/DatabaseAdapterFactory.php
@@ -5,6 +5,7 @@ namespace App\Factories;
 use App\Models\DatabaseConnection;
 use App\Services\Contracts\DatabaseAdapterInterface;
 use App\Services\Adapters\MySQLDatabaseAdapter;
+use App\Services\Adapters\PostgreSQLDatabaseAdapter;
 use InvalidArgumentException;
 
 class DatabaseAdapterFactory
@@ -13,6 +14,7 @@ class DatabaseAdapterFactory
     {
         return match (strtolower($connection->type)) {
             'mysql' => new MySQLDatabaseAdapter($connection),
+            'pgsql', 'postgres', 'postgresql' => new PostgreSQLDatabaseAdapter($connection),
             default => throw new InvalidArgumentException("Unsupported database type: {$connection->type}")
         };
     }

--- a/app/Http/Controllers/RestoreBackupController.php
+++ b/app/Http/Controllers/RestoreBackupController.php
@@ -24,7 +24,16 @@ class RestoreBackupController extends Controller
 
         // Run backup
         $restore_service = new RestoreBackupService(new ConfigService(), $adapter);
-        $restore_result = $restore_service->restore($validated);
+        try{
+            $restore_result = $restore_service->restore($validated);
+        }catch(\Exception $e){
+            return $this->errorResponse(
+                    'Restore DB failed',
+                    [
+                        'message' => $e->getMessage(),
+                    ],
+                );
+        }
 
         return $this->successResponse(
             null,
@@ -32,5 +41,4 @@ class RestoreBackupController extends Controller
             200,
         );
     }
-
 }

--- a/app/Services/Adapters/MySQLDatabaseAdapter.php
+++ b/app/Services/Adapters/MySQLDatabaseAdapter.php
@@ -25,19 +25,35 @@ class MySQLDatabaseAdapter implements DatabaseAdapterInterface
             mkdir($dir, 0755, true);
         }
 
+        // Step 1: Generate temporary .cnf file
+        $tempCnf = tempnam(sys_get_temp_dir(), 'mycnf_');
+
+        file_put_contents($tempCnf, "[client]
+            user={$this->connection->username}
+            password=\"{$this->connection->password}\"
+            host={$this->connection->host}
+            port={$this->connection->port}");
+
         $command = sprintf(
-            'mysqldump -u%s -p%s -h%s -P%s %s 2>&1 > %s',
-            escapeshellarg($this->connection->username),
-            escapeshellarg($this->connection->password),
-            escapeshellarg($this->connection->host),
-            $this->connection->port ?? 3306,
-            $this->connection->db_name,
+            'mysqldump --defaults-extra-file=%s %s 2>&1 > %s',
+            escapeshellarg($tempCnf),
+            escapeshellarg($this->connection->db_name),
             escapeshellarg($absolutePath)
-            );
+        );
+        // $command = sprintf(
+        //     'mysqldump -u%s -p%s -h%s -P%s %s 2>&1 > %s',
+        //     escapeshellarg($this->connection->username),
+        //     escapeshellarg($this->connection->password),
+        //     escapeshellarg($this->connection->host),
+        //     $this->connection->port ?? 3306,
+        //     $this->connection->db_name,
+        //     escapeshellarg($absolutePath)
+        //     );
 
        // Run command
         try {
         exec($command, $output, $exitCode);
+        unlink($tempCnf); // Always clean up, delete temp file
         $outputText = implode("\n", $output);
 
         if ($exitCode !== 0) {
@@ -84,19 +100,24 @@ class MySQLDatabaseAdapter implements DatabaseAdapterInterface
         if (!file_exists($filePath)) {
             throw new BackupFailedException("Backup file not found at: $filePath", 'file_not_found');
         }
+        
+        $tempCnf = tempnam(sys_get_temp_dir(), 'mycnf_');
 
-        // Build the restore command
+        file_put_contents($tempCnf, "[client]
+            user={$this->connection->username}
+            password=\"{$this->connection->password}\"
+            host={$this->connection->host}
+            port={$this->connection->port}");
+
         $command = sprintf(
-            'mysql -u%s -p%s -h%s -P%s %s < %s',
-            escapeshellarg($this->connection->username),
-            escapeshellarg($this->connection->password),
-            escapeshellarg($this->connection->host),
-            $this->connection->port ?? 3306,
+            'mysql --defaults-extra-file=%s %s < %s 2>&1',
+            escapeshellarg($tempCnf),
             escapeshellarg($this->connection->db_name),
             escapeshellarg($filePath)
         );
 
         exec($command . ' 2>&1', $output, $exitCode);
+        unlink($tempCnf); // Always clean up, delete temp file
         $outputText = implode("\n", $output);
 
         if ($exitCode !== 0) {
@@ -139,4 +160,3 @@ class MySQLDatabaseAdapter implements DatabaseAdapterInterface
         return true;
     }
 }
-

--- a/app/Services/Adapters/PostgreSQLDatabaseAdapter.php
+++ b/app/Services/Adapters/PostgreSQLDatabaseAdapter.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Services\Adapters;
+
+use App\Services\Contracts\DatabaseAdapterInterface;
+use App\Models\DatabaseConnection;
+use App\Exceptions\BackupFailedException;
+use Exception;
+
+class PostgreSQLDatabaseAdapter implements DatabaseAdapterInterface
+{
+    protected DatabaseConnection $connection;
+
+    public function __construct(DatabaseConnection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function backup(string $outputPath): bool
+    {
+        // Ensure the backup directory exists
+        $dir = dirname($outputPath);
+        if (!file_exists($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $cmd = sprintf(
+            'PGPASSWORD=%s /usr/bin/pg_dump -U %s -h %s -p %d -F p %s 2>&1',
+            escapeshellarg($this->connection->password),
+            escapeshellarg($this->connection->username),
+            escapeshellarg($this->connection->host),
+            $this->connection->port ?? 5432,
+            escapeshellarg($this->connection->db_name),
+            escapeshellarg($outputPath)
+        );
+
+        try {
+            $output = [];
+            $exitCode = 0;
+            exec($cmd, $output, $exitCode);
+            $outputText = implode("\n", $output);
+
+            if ($exitCode !== 0){
+                // Clean up empty file
+                if (file_exists($outputPath) && filesize($outputPath) === 0) {
+                    @unlink($outputPath);
+                }
+
+                if (
+                    preg_match('/password authentication failed/i', $outputText) ||
+                    preg_match('/role\s+".+"\s+does not exist/i', $outputText) ||
+                    preg_match('/FATAL:\s+.*authentication/i', $outputText)
+                ) {
+                    throw new BackupFailedException('Invalid PostgreSQL credentials or role does not exist.', 'invalid_credentials');
+                }
+                if (stripos($outputText, 'command not found') !== false) {
+                    throw new BackupFailedException('mysqldump command not found.', 'mysqldump_missing');
+                }
+                if (stripos($outputText, 'permission denied') !== false) {
+                    throw new BackupFailedException('Permission denied while writing backup file.', 'permission_denied');
+                }
+                if (stripos($outputText, 'no space left on device') !== false) {
+                    throw new BackupFailedException('Insufficient disk space for backup.', 'disk_full');
+                }
+                if (stripos($outputText, 'timed out') !== false) {
+                    throw new BackupFailedException('Database backup operation timed out.', 'timeout');
+                }
+                if (stripos($outputText, 'unknown mysql server host') !== false ||
+                    stripos($outputText, "can't connect to mysql server") !== false) {
+                    throw new BackupFailedException('Cannot connect to MySQL server.', 'host_unreachable');
+                }
+
+                // Unknown issue
+                throw new BackupFailedException("Backup failed with unknown error: $outputText", 'unknown');            
+            }
+
+            // Write to file only after success
+            file_put_contents($outputPath, implode("\n", $output));
+            
+            return true;
+        } catch (Exception $e) {
+            // rethrow for upper-level service to handle
+            throw $e;        
+        }
+    }
+
+    public function restore(string $filePath)
+    {
+        $cmd = sprintf(
+            'PGPASSWORD=%s /usr/bin/psql -U %s -h %s -p %d -d %s -f %s 2>&1',
+            escapeshellarg($this->connection->password),
+            escapeshellarg($this->connection->username),
+            escapeshellarg($this->connection->host),
+            $this->connection->port ?? 5432,
+            escapeshellarg($this->connection->db_name),
+            escapeshellarg($filePath)
+        );
+
+        try {
+            $output = [];
+            $exitCode = 0;
+            exec($cmd, $output, $exitCode);
+            $outputText = implode("\n", $output);
+
+            if ($exitCode !== 0) {
+                // Detect PostgreSQL-specific errors
+                if (
+                    stripos($outputText, 'password authentication failed') !== false ||
+                    stripos($outputText, 'role') !== false && stripos($outputText, 'does not exist') !== false ||
+                    stripos($outputText, 'FATAL') !== false && stripos($outputText, 'authentication') !== false
+                ) {
+                    throw new BackupFailedException('Invalid PostgreSQL credentials or role does not exist.', 'invalid_credentials');
+                }
+
+                if (stripos($outputText, 'permission denied') !== false) {
+                    throw new BackupFailedException('Permission denied while restoring database.', 'permission_denied');
+                }
+
+                if (stripos($outputText, 'No such file') !== false) {
+                    throw new BackupFailedException('Backup file does not exist.', 'file_missing');
+                }
+
+                throw new BackupFailedException("Restore failed: $outputText", 'unknown');
+            }
+
+            return true;
+        } catch (Exception $e) {
+            throw $e;
+        }
+    }
+
+
+    public function testConnection()
+    {
+        $cmd = sprintf(
+            'PGPASSWORD=%s pg_isready -U %s -h %s -p %d',
+            escapeshellarg($this->connection->password),
+            escapeshellarg($this->connection->username),
+            escapeshellarg($this->connection->host),
+            $this->connection->port ?? 5432
+        );
+
+        exec($cmd, $output, $exitCode);
+        if ($exitCode !== 0) {
+            throw new \Exception(implode("\n", $output)); // this is key
+        }
+
+        return $exitCode === 0;
+    }
+}


### PR DESCRIPTION
- Support postgres DB by implementing backup and restore methods.
- Use temporary .cnf file to store DB credentials (to secure password), then run the file, instead of executing command contain the password explicitly. and delete the temp file after excution.