### PR TITLE
Test CRUD for DBConnection Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 Homestead.json
 Homestead.yaml
 Thumbs.db
+.env.testing

--- a/database/factories/DatabaseConnectionFactory.php
+++ b/database/factories/DatabaseConnectionFactory.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Database\Factories;
+use Illuminate\Support\Facades\Crypt;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -16,8 +17,16 @@ class DatabaseConnectionFactory extends Factory
      */
     public function definition(): array
     {
+        $plainPassword = 'newuserpass';
+
         return [
-            //
+             'connection_name' => fake()->name(),
+            'type'            => 'mysql',
+            'host'            => '127.0.0.1',
+            'port'            => 3306,
+            'db_name'         => 'TechFlex',
+            'username'        => 'newuser',
+            'password'        => Crypt::encryptString($plainPassword),
         ];
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="mysql"/>
+        <env name="DB_DATABASE" value="Test-db-backup-utility"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/DBConnectionsTest.php
+++ b/tests/Feature/DBConnectionsTest.php
@@ -53,4 +53,29 @@ class DBConnectionsTest extends TestCase
             'connection_name' => 'fake name for testing',
         ]);
     }
+
+    public function test_update_specific_db_connection()
+    {
+        $db_connection = DatabaseConnection::factory()->create(['connection_name' => 'fake name']);
+        $data = [
+            'connection_name' => 'updated name',
+            'type'            => $db_connection->type,
+            'host'            => $db_connection->host,
+            'port'            => $db_connection->port,
+            'db_name'         => $db_connection->db_name,
+            'username'        => $db_connection->username,
+            'password'        => $db_connection->password, 
+        ];
+
+        $response = $this->putJson('api/database-connections/'.$db_connection->id,$data);
+
+        $response->assertStatus(202);
+        $response->assertJsonFragment([
+            'connection_name' => 'updated name',
+        ]);
+
+        $this->assertDatabaseHas('database_connections', [
+            'connection_name' => 'updated name',
+        ]);
+    }
 }

--- a/tests/Feature/DBConnectionsTest.php
+++ b/tests/Feature/DBConnectionsTest.php
@@ -15,7 +15,7 @@ class DBConnectionsTest extends TestCase
     public function test_return_all_db_connections()
     {
         DatabaseConnection::factory()->count(10)->create();
-        $response = $this->get('api/database-connections');
+        $response = $this->getJson('api/database-connections');
 
         $response->assertOk();
         $this->assertDatabaseCount('database_connections', 10);
@@ -24,7 +24,7 @@ class DBConnectionsTest extends TestCase
     public function test_return_specific_db_connection()
     {
         $db_connection = DatabaseConnection::factory()->create();
-        $response = $this->get('api/database-connections/'.$db_connection->id);
+        $response = $this->getJson('api/database-connections/'.$db_connection->id);
 
         $response->assertOk();
         $this->assertDatabaseCount('database_connections', 1);

--- a/tests/Feature/DBConnectionsTest.php
+++ b/tests/Feature/DBConnectionsTest.php
@@ -78,4 +78,14 @@ class DBConnectionsTest extends TestCase
             'connection_name' => 'updated name',
         ]);
     }
+
+     public function test_delete_specific_db_connection()
+    {
+        $db_connection = DatabaseConnection::factory()->create(['connection_name' => 'fake name for testing']);
+        $response = $this->deleteJson('api/database-connections/'.$db_connection->id);
+
+        $response->assertStatus(204);
+        $this->assertSoftDeleted($db_connection);
+    }
+    
 }

--- a/tests/Feature/DBConnectionsTest.php
+++ b/tests/Feature/DBConnectionsTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use App\Models\DatabaseConnection;
+use Illuminate\Support\Facades\Crypt;
 
 class DBConnectionsTest extends TestCase
 {
@@ -29,4 +30,27 @@ class DBConnectionsTest extends TestCase
         $this->assertDatabaseCount('database_connections', 1);
     }
 
+    public function test_store_new_db_connection()
+    {
+        $data = [
+            'connection_name' => 'fake name for testing',
+            'type'            => 'mysql',
+            'host'            => '127.0.0.1',
+            'port'            => 3306,
+            'db_name'         => 'TechFlex',
+            'username'        => 'newuser',
+            'password'        => Crypt::encryptString('newuserpass'),
+        ];
+
+        $response = $this->post('api/database-connections/',$data);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseCount('database_connections', 1);
+        $this->assertDatabaseHas('database_connections', [
+            'connection_name' => 'fake name for testing',
+        ]);
+        $response->assertJsonFragment([
+            'connection_name' => 'fake name for testing',
+        ]);
+    }
 }

--- a/tests/Feature/DBConnectionsTest.php
+++ b/tests/Feature/DBConnectionsTest.php
@@ -6,7 +6,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use App\Models\DatabaseConnection;
-use Illuminate\Support\Facades\Crypt;
 
 class DBConnectionsTest extends TestCase
 {
@@ -39,7 +38,7 @@ class DBConnectionsTest extends TestCase
             'port'            => 3306,
             'db_name'         => 'TechFlex',
             'username'        => 'newuser',
-            'password'        => Crypt::encryptString('newuserpass'),
+            'password'        => 'newuserpass',
         ];
 
         $response = $this->post('api/database-connections/',$data);
@@ -86,6 +85,23 @@ class DBConnectionsTest extends TestCase
 
         $response->assertStatus(204);
         $this->assertSoftDeleted($db_connection);
+    }
+
+    public function test_prevent_store_new_db_connection_with_invalid_inputs()
+    {
+        $data = [
+            'connection_name' => 'fake name for testing',
+            'type'            => 'wrong type',
+            'host'            => '127.0.0.1',
+            'port'            => 3306,
+            'db_name'         => 'TechFlex',
+            'username'        => 'newuser',
+            'password'        => 'newuserpass',
+        ];
+
+        $response = $this->postJson('api/database-connections/',$data);
+
+        $response->assertJsonValidationErrorFor('type');
     }
     
 }

--- a/tests/Feature/DBConnectionsTest.php
+++ b/tests/Feature/DBConnectionsTest.php
@@ -41,7 +41,7 @@ class DBConnectionsTest extends TestCase
             'password'        => 'newuserpass',
         ];
 
-        $response = $this->post('api/database-connections/',$data);
+        $response = $this->postJson('api/database-connections/',$data);
 
         $response->assertStatus(201);
         $this->assertDatabaseCount('database_connections', 1);
@@ -102,6 +102,21 @@ class DBConnectionsTest extends TestCase
         $response = $this->postJson('api/database-connections/',$data);
 
         $response->assertJsonValidationErrorFor('type');
+    }
+
+    public function test_prevent_store_new_db_connection_with_missing_inputs()
+    {
+        $data = [
+            'port'            => 3306,
+            'db_name'         => 'TechFlex',
+            'username'        => 'newuser',
+            'password'        => 'newuserpass',
+        ];
+
+        $response = $this->postJson('api/database-connections/',$data);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['connection_name', 'type', 'host']);
     }
     
 }

--- a/tests/Feature/DBConnectionsTest.php
+++ b/tests/Feature/DBConnectionsTest.php
@@ -20,5 +20,13 @@ class DBConnectionsTest extends TestCase
         $this->assertDatabaseCount('database_connections', 10);
     }
 
+    public function test_return_specific_db_connection()
+    {
+        $db_connection = DatabaseConnection::factory()->create();
+        $response = $this->get('api/database-connections/'.$db_connection->id);
+
+        $response->assertOk();
+        $this->assertDatabaseCount('database_connections', 1);
+    }
 
 }

--- a/tests/Feature/DBConnectionsTest.php
+++ b/tests/Feature/DBConnectionsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\DatabaseConnection;
+
+class DBConnectionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_return_all_db_connections()
+    {
+        DatabaseConnection::factory()->count(10)->create();
+        $response = $this->get('api/database-connections');
+
+        $response->assertOk();
+        $this->assertDatabaseCount('database_connections', 10);
+    }
+
+
+}


### PR DESCRIPTION
- Test CRUD for DBConnection Model .
- Test preventing store new model if there are missing/invalid inputs.