### PR TITLE
Test backup job API

### DIFF
--- a/app/Services/DatabaseBackupService.php
+++ b/app/Services/DatabaseBackupService.php
@@ -45,8 +45,9 @@ class DatabaseBackupService
         $connectionName = 'temp_' . uniqid();
         $filename = $connection->db_name.'_'.$connectionName . '_backup_' . now()->format('Ymd_His') . '.sql';
 
+        $storageBase = config('backup.storage_path', storage_path('app/backups'));
         $relativePath = trim($outputPath, '/') . '/' . $filename;
-        $absolutePath = storage_path('app/' . $relativePath);
+        $absolutePath = $storageBase . '/' . $relativePath;
 
         $sqlFile = $this->adapter->backup($absolutePath);  
 

--- a/config/backup.php
+++ b/config/backup.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'storage_path' => storage_path('app/backups'),
+];

--- a/database/factories/BackupJobFactory.php
+++ b/database/factories/BackupJobFactory.php
@@ -3,7 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-
+use App\Models\DatabaseConnection;
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\BackupJob>
  */
@@ -16,8 +16,24 @@ class BackupJobFactory extends Factory
      */
     public function definition(): array
     {
+        $start = $this->faker->dateTimeBetween('-1 day', 'now');
+        $end = (clone $start)->modify('+5 minutes');
+
+        //match service login
+        $connectionName = 'temp_' . uniqid();
+        $dbName = 'TechFlex'; 
+        $filename = $dbName . '_' . $connectionName . '_backup_' . now()->format('Ymd_His') . '.sql';
+        $path = 'backups/' . $filename;
+
         return [
-            //
+            'database_connection_id' => DatabaseConnection::factory(['db_name' => $dbName]), 
+            'backup_path'   => $path,
+            'status'        => 'completed',
+            'mechanism'     => 'manual',
+            'started_at'    => $start,
+            'completed_at'  => $end,
+            'file_size'     => $this->faker->numberBetween(100_000, 1_000_000), // in bytes
+            'error_message' => null, // or add fake message for failed jobs
         ];
     }
 }

--- a/tests/Feature/BackupJobTest.php
+++ b/tests/Feature/BackupJobTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use App\Models\DatabaseConnection;
+use App\Models\BackupJob;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 
@@ -20,6 +21,23 @@ class BackupJobTest extends TestCase
         $testBackupPath = storage_path('app/test-backups');
         File::ensureDirectoryExists($testBackupPath);
         Config::set('backup.storage_path', $testBackupPath);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(storage_path('app/test-backups'));
+
+        parent::tearDown();
+    }
+
+    public function test_return_all_backup_jobs()
+    {
+        BackupJob::factory()->count(4)->create();
+        $response = $this->getJson('api/backup-jobs');
+
+        $response->assertOk();
+        $response->assertJsonCount(4, 'data'); 
+        $this->assertDatabaseCount('backup_jobs', 4);
     }
 
     public function test_store_new_backup_job()
@@ -39,12 +57,7 @@ class BackupJobTest extends TestCase
         $this->assertNotEmpty($files);
     }
 
-    protected function tearDown(): void
-    {
-        File::deleteDirectory(storage_path('app/test-backups'));
-
-        parent::tearDown();
-    }
+    
 
    
 }

--- a/tests/Feature/BackupJobTest.php
+++ b/tests/Feature/BackupJobTest.php
@@ -53,6 +53,15 @@ class BackupJobTest extends TestCase
             ]);
         $this->assertDatabaseCount('backup_jobs', 1);
     }
+    
+    public function test_delete_specific_backup_job()
+    {
+        $backup_job = BackupJob::factory()->create();
+        $response = $this->deleteJson('api/backup-jobs/'.$backup_job->id);
+
+        $response->assertOk();
+        $this->assertSoftDeleted($backup_job);
+    }
 
     public function test_store_new_backup_job()
     {

--- a/tests/Feature/BackupJobTest.php
+++ b/tests/Feature/BackupJobTest.php
@@ -40,6 +40,20 @@ class BackupJobTest extends TestCase
         $this->assertDatabaseCount('backup_jobs', 4);
     }
 
+    public function test_return_specific_backup_job()
+    {
+        $backup_job = BackupJob::factory()->create();
+        $response = $this->getJson('api/backup-jobs/'.$backup_job->id);
+
+        $response->assertOk();
+        $response->assertJson([
+                'data' => [
+                    'id' => $backup_job->id,
+                ],
+            ]);
+        $this->assertDatabaseCount('backup_jobs', 1);
+    }
+
     public function test_store_new_backup_job()
     {
         $db_connection = DatabaseConnection::factory()->create();

--- a/tests/Feature/BackupJobTest.php
+++ b/tests/Feature/BackupJobTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\DatabaseConnection;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
+
+class BackupJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp():void
+    {
+        parent::setUp();
+  
+        $testBackupPath = storage_path('app/test-backups');
+        File::ensureDirectoryExists($testBackupPath);
+        Config::set('backup.storage_path', $testBackupPath);
+    }
+
+    public function test_store_new_backup_job()
+    {
+        $db_connection = DatabaseConnection::factory()->create();
+       
+        $data = ['db_id' => $db_connection->id];
+        $response = $this->postJson('api/backup-jobs/',$data);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseCount('backup_jobs', 1);
+
+        $this->assertDirectoryExists(storage_path('app/test-backups'));
+    
+        // Assert the backup file exists
+        $files = File::allFiles(storage_path('app/test-backups'));
+        $this->assertNotEmpty($files);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(storage_path('app/test-backups'));
+
+        parent::tearDown();
+    }
+
+   
+}

--- a/tests/Feature/BackupJobTest.php
+++ b/tests/Feature/BackupJobTest.php
@@ -53,7 +53,7 @@ class BackupJobTest extends TestCase
             ]);
         $this->assertDatabaseCount('backup_jobs', 1);
     }
-    
+
     public function test_delete_specific_backup_job()
     {
         $backup_job = BackupJob::factory()->create();
@@ -80,7 +80,13 @@ class BackupJobTest extends TestCase
         $this->assertNotEmpty($files);
     }
 
-    
+    public function test_prevent_store_backup_job_with_missing_inputs()
+    {
+        $response = $this->postJson('api/backup-jobs', []);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['db_id']);
+    }
 
    
 }

--- a/tests/Feature/BackupJobTest.php
+++ b/tests/Feature/BackupJobTest.php
@@ -88,5 +88,10 @@ class BackupJobTest extends TestCase
         $response->assertJsonValidationErrors(['db_id']);
     }
 
-   
+    public function test_store_backup_job_with_invalid_db_id()
+    {
+        $response = $this->postJson('api/backup-jobs', ['db_id' => 999]);
+
+        $response->assertStatus(422); 
+    }   
 }


### PR DESCRIPTION
- Created BackupJobFactory .
- Create config/backup.php to set the path for backup file. and used separate path to store dump files generated from testing, and i set that on setUp() in BackupJobTest class:
          $testBackupPath = storage_path('app/test-backups');
         File::ensureDirectoryExists($testBackupPath);
        Config::set('backup.storage_path', $testBackupPath);
and used tearDown() to cleaup all dumps generated via testing.
wrote tests for:
- Test store,index,show and delete methods for BackupJobController.
- Test if i passed invalid db_id to store new backup job.
- Test if  did not pass input(db_id) when calling store() to create new backup job.