### PR TITLE
Test restoring dump file 

### DIFF
--- a/app/Services/DatabaseBackupService.php
+++ b/app/Services/DatabaseBackupService.php
@@ -45,9 +45,8 @@ class DatabaseBackupService
         $connectionName = 'temp_' . uniqid();
         $filename = $connection->db_name.'_'.$connectionName . '_backup_' . now()->format('Ymd_His') . '.sql';
 
-        $storageBase = config('backup.storage_path', storage_path('app/backups'));
-        $relativePath = trim($outputPath, '/') . '/' . $filename;
-        $absolutePath = $storageBase . '/' . $relativePath;
+        $absolutePath = rtrim($outputPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
+        $relativePath = str_replace(storage_path('app/'), '', $absolutePath);
 
         $sqlFile = $this->adapter->backup($absolutePath);  
 

--- a/config/backup.php
+++ b/config/backup.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'storage_path' => storage_path('app/backups'),
+    'storage_path' => storage_path('app/'),
 ];

--- a/tests/Feature/RestoreDBTest.php
+++ b/tests/Feature/RestoreDBTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Tests\TestCase;
+use App\Models\DatabaseConnection;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Config;
+use App\Services\DatabaseBackupService;
+use App\Factories\DatabaseAdapterFactory;
+use App\Services\Compression\CompressionServiceInterface;
+
+class RestoreDBTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    protected string $storagePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Set test-specific backup path
+        $this->storagePath = storage_path('app/test-backups');
+
+        // Create the directory if it doesn't exist
+        if (!File::exists($this->storagePath)) {
+            File::makeDirectory($this->storagePath, 0777, true, true);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up the test-backups folder
+        if (File::exists($this->storagePath)) {
+            File::cleanDirectory($this->storagePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_retore_db_by_passing_db_id()
+    {
+        $db_connection = DatabaseConnection::factory()->create();
+
+        $compressor = app(CompressionServiceInterface::class);
+        $adapter = app(DatabaseAdapterFactory::class)->make($db_connection);
+
+        $backupService = new DatabaseBackupService($adapter,$compressor);
+        $backupJob = $backupService->backup($db_connection, $this->storagePath);
+
+        $fullPath = storage_path('app/' . $backupJob['relative_path']);
+        $data2 = [
+            'db_id' => $db_connection->id,
+            'file'  => $backupJob['relative_path']
+        ];
+
+        $response = $this->post('api/restore',$data2);
+        $response->assertOk();
+        $response->assertJson([
+            'message' => 'Database restored successfully.',
+        ]);
+        $this->assertNotNull($fullPath, 'Backup path should not be null');
+        $this->assertTrue(file_exists($fullPath), "Backup file does not exist: $fullPath");
+    }
+
+}


### PR DESCRIPTION
Test restoring dump file generated using DatabaseBackupService and pass (test-backup) as a path to separate test dumps from the original dumps, so it  becomes easier to clean them later after testing
