### PR TITLE
Restore db using profile

### DIFF
--- a/app/Console/Commands/AddDBProfile.php
+++ b/app/Console/Commands/AddDBProfile.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use App\Services\ConfigService;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Crypt;
 
 class AddDBProfile extends Command
 {
@@ -51,6 +52,9 @@ class AddDBProfile extends Command
             }
             return 1;
         }
+
+        // Encrypt the password before storing it
+        $input['password'] = Crypt::encryptString($input['password']);
 
         $profiles = $this->configService->loadProfiles();
 

--- a/app/Console/Commands/BackupDatabase.php
+++ b/app/Console/Commands/BackupDatabase.php
@@ -8,20 +8,21 @@ use App\Services\DatabaseBackupService;
 use App\Models\DatabaseConnection;
 use App\Exceptions\BackupFailedException;
 use Illuminate\Support\Facades\Log;
+use App\Factories\DatabaseAdapterFactory;
+use App\Services\Compression\CompressionServiceInterface;
 
 class BackupDatabase extends Command
 {
-    // protected $signature = 'db:backup {client_id}';
     protected $signature = 'db:backup {id?} {--profile=}';
     protected $description = 'Backup The Database';
 
-    protected DatabaseBackupService $backupService;
     protected ConfigService $configService;
 
-    public function __construct(DatabaseBackupService $backupService, ConfigService $configService)
+    public function __construct( ConfigService $configService)
     {
+        // NOTE: Cannot inject DatabaseBackupService in constructor because
+        // it depends on a runtime-specific adapter (resolved after knowing the DB type).
         parent::__construct();
-        $this->backupService = $backupService;
         $this->configService = $configService;
     }
 
@@ -30,7 +31,7 @@ class BackupDatabase extends Command
     {
         $id = $this->argument('id');
         $profileName = $this->option('profile');
-        $outputPath = 'backups'; // Directory where backups will be stored
+        $outputPath = config('backup.storage_path') . '/backups'; // Directory where backups will be stored
 
         // Ensure one of the options is provided
         if (!$id && !$profileName) {
@@ -61,7 +62,12 @@ class BackupDatabase extends Command
                 }
 
                 $dbConfig = $profiles[$profileName];
-                $result = $this->backupService->backupUsingProfile($dbConfig, $outputPath);
+                           
+                $adapter = (new DatabaseAdapterFactory())->makeFromProfile($dbConfig);
+                $compressor = app(CompressionServiceInterface::class);
+                $backupService = new DatabaseBackupService($adapter, $compressor);
+
+                $result = $backupService->backupUsingProfile($dbConfig, $outputPath); // assuming this method exists
             }
             else // Handle ID-based backup
             {
@@ -78,7 +84,11 @@ class BackupDatabase extends Command
                     return Command::FAILURE;
                 }
 
-                $result = $this->backupService->backup($id, $outputPath);
+                $adapter = (new DatabaseAdapterFactory())->make($connection);
+                $compressor = app(CompressionServiceInterface::class);
+                $backupService = new DatabaseBackupService($adapter, $compressor);
+
+                $result = $backupService->backup($connection, $outputPath);
             }
 
             $duration = now()->diffInSeconds($logContext['invoked_at']);

--- a/app/Factories/DatabaseAdapterFactory.php
+++ b/app/Factories/DatabaseAdapterFactory.php
@@ -18,4 +18,13 @@ class DatabaseAdapterFactory
             default => throw new InvalidArgumentException("Unsupported database type: {$connection->type}")
         };
     }
+
+    public function makeFromProfile(array $profile): DatabaseAdapterInterface
+    {
+        return match (strtolower($profile['driver'])) {
+            'mysql' => new MySQLDatabaseAdapter($profile),
+            'pgsql', 'postgres', 'postgresql' => new PostgreSQLDatabaseAdapter($profile),
+            default => throw new \InvalidArgumentException("Unsupported database type: {$profile['type']}")
+        };
+    }
 }

--- a/app/Http/Controllers/BackupJobController.php
+++ b/app/Http/Controllers/BackupJobController.php
@@ -58,7 +58,8 @@ class BackupJobController extends Controller
             
             // Run backup
             $backupService = new DatabaseBackupService($adapter,$compressor);
-            $backupResult = $backupService->backup($db_connection, 'backups');// pass the absolute path 
+            $path = config('backup.storage_path') . '/backups';
+            $backupResult = $backupService->backup($db_connection, $path);// pass the absolute path 
            
             $backupJob->update([ // Update job record with success
                 'status'       => 'completed',

--- a/app/Http/Controllers/RestoreBackupController.php
+++ b/app/Http/Controllers/RestoreBackupController.php
@@ -12,7 +12,6 @@ use App\Traits\ApiResponseTrait;
 use App\Services\Compression\DecompressionServiceInterface;
 use Symfony\Component\HttpFoundation\Response;
 
-
 class RestoreBackupController extends Controller
 {
     use ApiResponseTrait;
@@ -20,12 +19,6 @@ class RestoreBackupController extends Controller
     function restoreBackup(RestoreBackupRequest $request)
     {
         $validated = $request->validated();
-        $connection = DatabaseConnection::findOrFail($validated['db_id']);
-
-        // Use factory to resolve correct adapter
-        $adapterFactory = new DatabaseAdapterFactory();
-        $adapter = $adapterFactory->make($connection);
-
 
         $filePath = null;
         $pathToBackupFile = $validated['file'];
@@ -44,12 +37,25 @@ class RestoreBackupController extends Controller
                     Response::HTTP_UNPROCESSABLE_ENTITY
                 );
             }
-            
         } else {
             $filePath = $pathToBackupFile;
         }
-
         $validated['file'] = $filePath;
+
+        // Use factory to resolve correct adapter
+        $adapterFactory = new DatabaseAdapterFactory();
+        $adapter = null;
+        if (isset($validated['db_id'])) 
+        {
+            $connection = DatabaseConnection::findOrFail($validated['db_id']);
+            $adapter = $adapterFactory->make($connection);
+        } elseif (isset($validated['db_profile'])) {
+            $profileName = $request->input('db_profile'); 
+            $configService = new ConfigService();
+            $profile = $configService->getProfile($profileName);
+            $adapter = $adapterFactory->makeFromProfile($profile);
+        }
+
         $restore_service = new RestoreBackupService(new ConfigService(), $adapter);
         
         try{// Run restore operation

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,7 +16,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->bind(DatabaseAdapterInterface::class,MySQLDatabaseAdapter::class);
         $this->app->bind(CompressionServiceInterface::class,GzipCompressionService::class);
         $this->app->bind( DecompressionServiceInterface::class,GzipCompressionService::class);
     }

--- a/app/Services/Adapters/MySQLDatabaseAdapter.php
+++ b/app/Services/Adapters/MySQLDatabaseAdapter.php
@@ -12,11 +12,27 @@ use Illuminate\Support\Facades\Crypt;
 class MySQLDatabaseAdapter implements DatabaseAdapterInterface
 {
 
-    protected DatabaseConnection $connection;
+    protected string $host;
+    protected string $port;
+    protected string $username;
+    protected string $password;
+    protected string $db_name;
 
-    public function __construct(DatabaseConnection $connection)
+    public function __construct(DatabaseConnection|array $connection)
     {
-        $this->connection = $connection;
+        if (is_array($connection)) {
+            $this->host = $connection['host'];
+            $this->port = $connection['port'];
+            $this->username = $connection['username'];
+            $this->password = $connection['password'];// already decrypted
+            $this->db_name = $connection['database'];
+        } else {
+            $this->host = $connection->host;
+            $this->port = $connection->port;
+            $this->username = $connection->username;
+            $this->password = Crypt::decryptString($connection->password);
+            $this->db_name = $connection->db_name;
+        }
     }
 
     public function backup(string $absolutePath)
@@ -30,14 +46,12 @@ class MySQLDatabaseAdapter implements DatabaseAdapterInterface
         // Step 1: Generate temporary .cnf file
         $tempCnf = tempnam(sys_get_temp_dir(), 'mycnf_');
 
-        $password = Crypt::decryptString($this->connection->password);
-
         $configg = <<<CNF
         [client]
-        user={$this->connection->username}
-        password={$password}
-        host={$this->connection->host}
-        port={$this->connection->port}
+        user={$this->username}
+        password={$this->password}
+        host={$this->host}
+        port={$this->port}
         CNF;
 
         file_put_contents($tempCnf, $configg);
@@ -45,7 +59,7 @@ class MySQLDatabaseAdapter implements DatabaseAdapterInterface
         $command = sprintf(
             'mysqldump --defaults-extra-file=%s %s 2>&1 > %s',
             escapeshellarg($tempCnf),
-            escapeshellarg($this->connection->db_name),
+            escapeshellarg($this->db_name),
             escapeshellarg($absolutePath)
         );
 
@@ -102,18 +116,16 @@ class MySQLDatabaseAdapter implements DatabaseAdapterInterface
         
         $tempCnf = tempnam(sys_get_temp_dir(), 'mycnf_');
 
-        $password = Crypt::decryptString($this->connection->password);
-
         file_put_contents($tempCnf, "[client]
-            user={$this->connection->username}
-            password=\"{$password}\"
-            host={$this->connection->host}
-            port={$this->connection->port}");
+            user={$this->username}
+            password=\"{$this->password}\"
+            host={$this->host}
+            port={$this->port}");
 
         $command = sprintf(
             'mysql --defaults-extra-file=%s %s < %s 2>&1',
             escapeshellarg($tempCnf),
-            escapeshellarg($this->connection->db_name),
+            escapeshellarg($this->db_name),
             escapeshellarg($filePath)
         );
 
@@ -143,15 +155,13 @@ class MySQLDatabaseAdapter implements DatabaseAdapterInterface
 
     public function testConnection(): bool
     {
-        $password = Crypt::decryptString($this->connection->password);
-
         $cmd = sprintf(
             'mysql -u%s -p%s -h%s -P%s -e "USE %s;"',
-            escapeshellarg($this->connection->username),
-            escapeshellarg($password),
-            escapeshellarg($this->connection->host),
+            escapeshellarg($this->username),
+            escapeshellarg($this->password),
+            escapeshellarg($this->host),
             $this->connection->port ?? 3306,
-            escapeshellarg($this->connection->db_name)
+            escapeshellarg($this->db_name)
         );
 
         exec($cmd . ' 2>&1', $output, $exitCode);

--- a/app/Services/Adapters/PostgreSQLDatabaseAdapter.php
+++ b/app/Services/Adapters/PostgreSQLDatabaseAdapter.php
@@ -13,11 +13,27 @@ use Illuminate\Support\Facades\Crypt;
 
 class PostgreSQLDatabaseAdapter implements DatabaseAdapterInterface
 {
-    protected DatabaseConnection $connection;
+    protected string $host;
+    protected string $port;
+    protected string $username;
+    protected string $password;
+    protected string $db_name;
 
-    public function __construct(DatabaseConnection $connection)
+    public function __construct(DatabaseConnection|array $connection)
     {
-        $this->connection = $connection;
+        if (is_array($connection)) {
+            $this->host = $connection['host'];
+            $this->port = $connection['port'];
+            $this->username = $connection['username'];
+            $this->password = $connection['password'];// already decrypted
+            $this->db_name = $connection['database'];
+        } else {
+            $this->host = $connection->host;
+            $this->port = $connection->port;
+            $this->username = $connection->username;
+            $this->password = Crypt::decryptString($connection->password);
+            $this->db_name = $connection->db_name;
+        }
     }
 
     public function backup(string $outputPath)
@@ -28,15 +44,13 @@ class PostgreSQLDatabaseAdapter implements DatabaseAdapterInterface
             mkdir($dir, 0755, true);
         }
 
-        $password = Crypt::decryptString($this->connection->password);
-
         $cmd = sprintf(
             'PGPASSWORD=%s /usr/bin/pg_dump -U %s -h %s -p %d -F p %s 2>&1',
-            escapeshellarg($password),
-            escapeshellarg($this->connection->username),
-            escapeshellarg($this->connection->host),
-            $this->connection->port ?? 5432,
-            escapeshellarg($this->connection->db_name),
+            escapeshellarg($this->password),
+            escapeshellarg($this->username),
+            escapeshellarg($this->host),
+            $this->port ?? 5432,
+            escapeshellarg($this->db_name),
             escapeshellarg($outputPath)
         );
 
@@ -92,15 +106,13 @@ class PostgreSQLDatabaseAdapter implements DatabaseAdapterInterface
 
     public function restore(string $filePath)
     {
-        $password = Crypt::decryptString($this->connection->password);
-
         $cmd = sprintf(
             'PGPASSWORD=%s /usr/bin/psql -U %s -h %s -p %d -d %s -f %s 2>&1',
-            escapeshellarg($password),
-            escapeshellarg($this->connection->username),
-            escapeshellarg($this->connection->host),
-            $this->connection->port ?? 5432,
-            escapeshellarg($this->connection->db_name),
+            escapeshellarg($this->password),
+            escapeshellarg($this->username),
+            escapeshellarg($this->host),
+            $this->port ?? 5432,
+            escapeshellarg($this->db_name),
             escapeshellarg($filePath)
         );
 
@@ -140,14 +152,12 @@ class PostgreSQLDatabaseAdapter implements DatabaseAdapterInterface
 
     public function testConnection()
     {
-        $password = Crypt::decryptString($this->connection->password);
-
         $cmd = sprintf(
             'PGPASSWORD=%s pg_isready -U %s -h %s -p %d',
-            escapeshellarg($password),
-            escapeshellarg($this->connection->username),
-            escapeshellarg($this->connection->host),
-            $this->connection->port ?? 5432
+            escapeshellarg($this->password),
+            escapeshellarg($this->username),
+            escapeshellarg($this->host),
+            $this->port ?? 5432
         );
 
         exec($cmd, $output, $exitCode);

--- a/app/Services/ConfigService.php
+++ b/app/Services/ConfigService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Crypt;
 
 class ConfigService
 {
@@ -35,7 +36,19 @@ class ConfigService
     {
         $this->ensureConfigFileExists();
         $data = json_decode(File::get($this->configPath), true);
-        return $data['profiles'] ?? [];
+        $profiles = $data['profiles'] ?? [];
+
+        foreach ($profiles as $name => &$profile) 
+        {
+            if (isset($profile['password']) && is_string($profile['password'])) {
+                try {
+                    $profile['password'] = Crypt::decryptString($profile['password']);
+                } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
+                    // Password was not encrypted (maybe plain text), leave it as-is
+                }
+            }
+        }
+        return $profiles;
     }
 
     public function saveProfiles(array $profiles): void

--- a/app/Services/ConfigService.php
+++ b/app/Services/ConfigService.php
@@ -56,4 +56,10 @@ class ConfigService
         $data = ['profiles' => $profiles];
         File::put($this->configPath, json_encode($data, JSON_PRETTY_PRINT));
     }
+
+    public function getProfile(string $name): ?array
+    {
+        $profiles = $this->loadProfiles();
+        return $profiles[$name] ?? null;
+    }
 }


### PR DESCRIPTION
- Encrypt password before store it to config.json. and decrypt it in loadProfiles().
- Refactor: RestoreController so it could also support restoring DB using profile from config.json(besides supporting restore using db_id).
- Refactor:DatabaseAdapterFactory class by adding makeFromProfile() to return the correct adapter(DB driver) from the config profile, so it checks the profile to decide if its mysql or postgres. my old make() deal with DatabaseConnection model in case of using db_id to backup/restore DB.
- Refactor:ConfigService class by adding getProfile() that return an array contain the profile's data (driver, database, port, username,..).
- Refactor:adapters(mysql/postgres) constructors. the old constructor inject DatabaseConnection model, and now support backup/restore with db_id and profile also. so prepared the construct to handle both.
- remove direct/restrict interface binding(to Mysql). and dynamically resolve adapter (MySQL or PostgreSQL)
- Refactor:BackupCOntroller class by using config/backup.php content(use the path i configed, so dumps goes to storage/app/backups).
- Refactor:BackupDatabase class by edit constructor so defer DatabaseBackupService instantiation to runtime, and resolve it dynamically inside handle(). after things known(would use id/profile).since the adapter type (MySQL/PostgreSQL) depends on user input (id or --profile).This prevents container resolution errors due to unbound interfaces.
In CLI you don’t know the database type (MySQL, PostgreSQL...) until id or profile is passed.



 
 

