### PR TITLE
Refactor backup via cli

### DIFF
--- a/app/Console/Commands/BackupDatabase.php
+++ b/app/Console/Commands/BackupDatabase.php
@@ -95,12 +95,12 @@ class BackupDatabase extends Command
 
             // Handle success response
             $this->info("✅ Backup successful!");
-            $this->line("📁 File Path: storage/app/{$result['file_path']}");
+            $this->line("📁 File Path: storage/app{$result['relative_path']}");
             $this->line("📦 Size: {$result['file_size']} bytes");
 
             //log after backup operation success
             Log::info("✅ CLI Backup Success", array_merge($logContext, [
-                'file_path' => $result['file_path'],
+                'file_path' => $result['relative_path'],
                 'file_size' => $result['file_size'],
                 'duration'  => $duration,
             ]));

--- a/app/Console/Commands/BackupDatabase.php
+++ b/app/Console/Commands/BackupDatabase.php
@@ -67,7 +67,7 @@ class BackupDatabase extends Command
                 $compressor = app(CompressionServiceInterface::class);
                 $backupService = new DatabaseBackupService($adapter, $compressor);
 
-                $result = $backupService->backupUsingProfile($dbConfig, $outputPath); // assuming this method exists
+                $result = $backupService->backupUsingProfile($dbConfig, $outputPath); // assuming this method exists            
             }
             else // Handle ID-based backup
             {
@@ -88,7 +88,7 @@ class BackupDatabase extends Command
                 $compressor = app(CompressionServiceInterface::class);
                 $backupService = new DatabaseBackupService($adapter, $compressor);
 
-                $result = $backupService->backup($connection, $outputPath);
+                $result = $backupService->backupUsingDbId($connection, $outputPath);
             }
 
             $duration = now()->diffInSeconds($logContext['invoked_at']);

--- a/app/Services/Adapters/MySQLDatabaseAdapter.php
+++ b/app/Services/Adapters/MySQLDatabaseAdapter.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\Crypt;
 
 class MySQLDatabaseAdapter implements DatabaseAdapterInterface
 {
-
     protected string $host;
     protected string $port;
     protected string $username;
@@ -35,7 +34,7 @@ class MySQLDatabaseAdapter implements DatabaseAdapterInterface
         }
     }
 
-    public function backup(string $absolutePath)
+    public function backupViaDbId(string $absolutePath)
     {
         // Ensure the backup directory exists
         $dir = dirname($absolutePath);
@@ -103,6 +102,56 @@ class MySQLDatabaseAdapter implements DatabaseAdapterInterface
 
         } catch (BackupFailedException $e) {
             // rethrow for upper-level service to handle
+            throw $e;
+        }
+    }
+
+    public function backupViaProfile(array $profile,string $absolutePath)
+    {
+        $command = sprintf(
+            'mysqldump --user=%s --password=%s --host=%s --port=%s %s 2>&1 > %s',
+            escapeshellarg($profile['username']),
+            escapeshellarg($profile['password']),
+            escapeshellarg($profile['host']),
+            escapeshellarg($profile['port'] ?? '3306'),
+            escapeshellarg($profile['database']),
+            escapeshellarg($absolutePath)
+        );
+
+        $output = [];
+        $result = 0;
+        try{
+            exec($command, $output, $result);
+            $outputText = implode("\n", $output);
+
+            if ($result !== 0) {
+                // same error checks as before
+                if (stripos($outputText, 'access denied') !== false) {
+                    throw new BackupFailedException('Invalid database credentials.', 'invalid_credentials');
+                }
+                if (stripos($outputText, 'mysqldump') !== false && stripos($outputText, 'not found') !== false) {
+                    throw new BackupFailedException('mysqldump command not found.', 'mysqldump_missing');
+                }
+                if (stripos($outputText, 'permission denied') !== false) {
+                    throw new BackupFailedException('Permission denied while writing backup file.', 'permission_denied');
+                }
+                if (stripos($outputText, 'no space left') !== false) {
+                    throw new BackupFailedException('Insufficient disk space for backup.', 'disk_full');
+                }
+                if (stripos($outputText, 'timed out') !== false) {
+                    throw new BackupFailedException('Database backup operation timed out.', 'timeout');
+                }
+                if (stripos($outputText, 'unknown mysql server host') !== false) {
+                    throw new BackupFailedException('Unknown MySQL server host.', 'host_unreachable');
+                }
+                if (stripos($outputText, "can't connect to mysql server") !== false) {
+                    throw new BackupFailedException('Cannot connect to MySQL server on the specified host.', 'host_unreachable');
+                }
+
+                throw new BackupFailedException("Backup failed: $outputText", 'unknown');
+            }
+            return $absolutePath;
+        } catch (BackupFailedException $e) {
             throw $e;
         }
     }

--- a/app/Services/Contracts/DatabaseAdapterInterface.php
+++ b/app/Services/Contracts/DatabaseAdapterInterface.php
@@ -4,7 +4,9 @@ namespace App\Services\Contracts;
 
 interface DatabaseAdapterInterface
 {
-    public function backup(String $outputPath);
+    public function backupViaDbId(String $outputPath);
+
+    public function backupViaProfile(array $profile,string $outputPath);
 
     public function testConnection();
 

--- a/app/Services/DatabaseBackupService.php
+++ b/app/Services/DatabaseBackupService.php
@@ -12,7 +12,6 @@ use App\Services\Compression\CompressionServiceInterface;
 
 class DatabaseBackupService
 {
-
     protected DatabaseAdapterInterface $adapter;
 
     public function __construct(DatabaseAdapterInterface $adapter, protected CompressionServiceInterface $compressor)
@@ -20,7 +19,7 @@ class DatabaseBackupService
         $this->adapter = $adapter;
     }
 
-    public function backup(DatabaseConnection $connection, string $outputPath): array
+    public function backupUsingDbId(DatabaseConnection $connection, string $outputPath): array
     {
         try {
             $this->adapter->testConnection();
@@ -48,7 +47,7 @@ class DatabaseBackupService
         $absolutePath = rtrim($outputPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
         $relativePath = str_replace(storage_path('app/'), '', $absolutePath);
 
-        $sqlFile = $this->adapter->backup($absolutePath);  
+        $sqlFile = $this->adapter->backupViaDbId($absolutePath);  
 
         try { // compress dump file
             $gzFile = $this->compressor->compress($sqlFile, level: 6);
@@ -67,67 +66,37 @@ class DatabaseBackupService
         ];
     }
 
-    public function backupUsingProfile($config,$outputPath)
+    public function backupUsingProfile(array $profile,string $outputPath)
     {
-        // First: test connection dynamically
-        TestDatabaseConnectionService::testProfileConnection($config);
+        try {// First: test connection dynamically
+            TestDatabaseConnectionService::testProfileConnection($profile); 
+        } catch (\Exception $e) {
+            throw $e;
+        }
         
         // File name format
-        $filename = "{$config['database']}_backup_" . date('Ymd_His') . ".sql";
-        $relativePath = "{$outputPath}/{$filename}";
-        $fullPath = storage_path('app/' . $relativePath);
+        $filename = "{$profile['database']}_backup_" . date('Ymd_His') . ".sql";
 
-        $command = sprintf(
-            'mysqldump --user=%s --password=%s --host=%s --port=%s %s 2>&1 > %s',
-            escapeshellarg($config['username']),
-            escapeshellarg($config['password']),
-            escapeshellarg($config['host']),
-            escapeshellarg($config['port'] ?? '3306'),
-            escapeshellarg($config['database']),
-            escapeshellarg($fullPath)
-        );
+        $absolutePath = rtrim($outputPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
+        $relativePath = str_replace(storage_path('app/'), '', $absolutePath);
 
-        $output = [];
-        $result = 0;
-        exec($command, $output, $result);
-
-        $outputText = implode("\n", $output);
-
-        if ($result !== 0) {
-            // same error checks as before
-            if (stripos($outputText, 'access denied') !== false) {
-                throw new BackupFailedException('Invalid database credentials.', 'invalid_credentials');
-            }
-            if (stripos($outputText, 'mysqldump') !== false && stripos($outputText, 'not found') !== false) {
-                throw new BackupFailedException('mysqldump command not found.', 'mysqldump_missing');
-            }
-            if (stripos($outputText, 'permission denied') !== false) {
-                throw new BackupFailedException('Permission denied while writing backup file.', 'permission_denied');
-            }
-            if (stripos($outputText, 'no space left') !== false) {
-                throw new BackupFailedException('Insufficient disk space for backup.', 'disk_full');
-            }
-            if (stripos($outputText, 'timed out') !== false) {
-                throw new BackupFailedException('Database backup operation timed out.', 'timeout');
-            }
-            if (stripos($outputText, 'unknown mysql server host') !== false) {
-                throw new BackupFailedException('Unknown MySQL server host.', 'host_unreachable');
-            }
-            if (stripos($outputText, "can't connect to mysql server") !== false) {
-                throw new BackupFailedException('Cannot connect to MySQL server on the specified host.', 'host_unreachable');
-            }
-
-            throw new BackupFailedException("Backup failed: $outputText", 'unknown');
+        $dumplFile = $this->adapter->backupViaProfile($profile,$absolutePath);
+        
+        try { // compress dump file
+            $gzFile = $this->compressor->compress($dumplFile, level: 6);
+            Log::info("Backup compressed: {$gzFile}");
+        } catch (CompresionFailedException $e) {
+            Log::error("Compression failed: " . $e->getMessage());
+            throw $e;
         }
+        
+        $fileSize = file_exists($absolutePath) ? filesize($absolutePath) : null;
 
-        $fileSize = file_exists($fullPath) ? filesize($fullPath) : 0;
+        return [
+            'relative_path' => $relativePath,
+            'absolute_path' => $absolutePath,
+            'file_size'     => $fileSize,
+        ];
 
-        if ($result === 0 && $fileSize > 0) {
-            return [
-                'status'    => true,
-                'file_path' => $relativePath,
-                'file_size' => $fileSize,
-            ];
-        }
     }
 }

--- a/app/Services/TestDatabaseConnectionService.php
+++ b/app/Services/TestDatabaseConnectionService.php
@@ -78,19 +78,19 @@ class TestDatabaseConnectionService
         }
     }
 
-    public static function testProfileConnection(array $config)
+    public static function testProfileConnection(array $profile)
     {
         $connectionName = 'profile_' . uniqid();
 
         \Illuminate\Support\Facades\DB::purge($connectionName);
 
         \Illuminate\Support\Facades\Config::set("database.connections.{$connectionName}", [
-            'driver'    => $config['driver'] ?? 'mysql',
-            'host'      => $config['host'],
-            'port'      => $config['port'],
-            'database'  => $config['database'],
-            'username'  => $config['username'],
-            'password'  => $config['password'],
+            'driver'    => $profile['driver'] ?? 'mysql',
+            'host'      => $profile['host'],
+            'port'      => $profile['port'],
+            'database'  => $profile['database'],
+            'username'  => $profile['username'],
+            'password'  => $profile['password'],
             'charset'   => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix'    => '',


### PR DESCRIPTION
- Fix name from file_path to relative_path, and remove the extra (/) from the file path in success response.
- Refactor: DatabaseAdapterInterface class by adding backupViaProfile() to handle backup via profile, and rename the old backup() to backupViaId() to handle backup via id.
Implements those methods in Mysqladapter class.
-Refactor: BackupDatabase artisan command to be able to support backuping use both profile and id.
