### PR TITLE
Test backup status command

### DIFF
--- a/app/Console/Commands/BackupStatus.php
+++ b/app/Console/Commands/BackupStatus.php
@@ -16,15 +16,15 @@ class BackupStatus extends Command
 
         foreach ($jobs as $job) {
             // display job info here
-            echo "Backup ID: {$job->id}\n";
-            echo "Status: {$job->status}\n";
-            echo "Started At: {$job->started_at}\n";
-            echo "Completed At: {$job->completed_at}\n";
-            echo "File Size: {$job->file_size}\n";
+            $this->line("Backup ID: {$job->id}");
+            $this->line("Status: {$job->status}");
+            $this->line("Started At: {$job->started_at}");
+            $this->line("Completed At: {$job->completed_at}");
+            $this->line("File Size: {$job->file_size}");
             if ($job->error_message) {
-                echo "Error: {$job->error_message}\n";
+                $this->error("Error: {$job->error_message}");
             }
-            echo "--------------------\n";
+            $this->line("--------------------");
         }
         return Command::SUCCESS;
     }

--- a/app/Console/Commands/BackupStatus.php
+++ b/app/Console/Commands/BackupStatus.php
@@ -14,6 +14,11 @@ class BackupStatus extends Command
     {
         $jobs = BackupJob::where('mechanism', 'automated')->orderBy('created_at', 'desc')->get();
 
+        if ($jobs->isEmpty()) {
+            $this->warn('⚠️  No automated backup jobs found.');
+            return Command::SUCCESS;
+        }
+        
         foreach ($jobs as $job) {
             // display job info here
             $this->line("Backup ID: {$job->id}");

--- a/tests/Feature/BackupStatusCommandTest.php
+++ b/tests/Feature/BackupStatusCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\BackupJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class BackupStatusCommandTest extends TestCase
+{
+    use RefreshDatabase;
+    
+    public function test_backup_status_command()
+    {
+        $jobs = BackupJob::factory()->count(3)->create(['mechanism' => 'automated']);
+
+        $this->artisan('backup:status')
+            ->expectsOutput("Backup ID: {$jobs[0]->id}")
+            ->expectsOutput("Backup ID: {$jobs[1]->id}")
+            ->expectsOutput("Backup ID: {$jobs[2]->id}")
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Feature/BackupStatusCommandTest.php
+++ b/tests/Feature/BackupStatusCommandTest.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 class BackupStatusCommandTest extends TestCase
 {
     use RefreshDatabase;
-    
+
     public function test_backup_status_command()
     {
         $jobs = BackupJob::factory()->count(3)->create(['mechanism' => 'automated']);
@@ -18,6 +18,13 @@ class BackupStatusCommandTest extends TestCase
             ->expectsOutput("Backup ID: {$jobs[0]->id}")
             ->expectsOutput("Backup ID: {$jobs[1]->id}")
             ->expectsOutput("Backup ID: {$jobs[2]->id}")
+            ->assertExitCode(0);
+    }
+
+    public function test_backup_status_command_with_no_jobs_founded()
+    {
+        $this->artisan('backup:status')
+            ->expectsOutput("⚠️  No automated backup jobs found.")
             ->assertExitCode(0);
     }
 }

--- a/tests/Feature/BackupStatusCommandTest.php
+++ b/tests/Feature/BackupStatusCommandTest.php
@@ -27,4 +27,13 @@ class BackupStatusCommandTest extends TestCase
             ->expectsOutput("⚠️  No automated backup jobs found.")
             ->assertExitCode(0);
     }
+
+    public function test_backup_status_command_with_only_manual_jobs()
+    {
+        BackupJob::factory()->create(['mechanism' => 'manual']);
+
+        $this->artisan('backup:status')
+            ->expectsOutput('⚠️  No automated backup jobs found.')
+            ->assertExitCode(0);
+    }
 }


### PR DESCRIPTION
- Refactor BackupStatus command by use ($this->line) for printing instead of echo(). And handle if there is no automated jobs returned from the DB by printing a message.
Write test cases BackupStatus command.