### PR TITLE
just classify test files into separate folders

### DIFF
--- a/tests/Feature/APITests/BackupJobTest.php
+++ b/tests/Feature/APITests/BackupJobTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\APITests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;

--- a/tests/Feature/APITests/BackupScheduleTest.php
+++ b/tests/Feature/APITests/BackupScheduleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\APITests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;

--- a/tests/Feature/APITests/DBConnectionsTest.php
+++ b/tests/Feature/APITests/DBConnectionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\APITests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;

--- a/tests/Feature/APITests/RestoreDBTest.php
+++ b/tests/Feature/APITests/RestoreDBTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\APITests;
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Tests\TestCase;

--- a/tests/Feature/ConsoleExceptionTests/BackupDatabaseCommandExceptionFailureTest.php
+++ b/tests/Feature/ConsoleExceptionTests/BackupDatabaseCommandExceptionFailureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\ConsoleExceptionTests;
 
 use Tests\TestCase;
 use App\Models\DatabaseConnection;

--- a/tests/Feature/ConsoleExceptionTests/RunScheduledBackupsCommandFailureTest.php
+++ b/tests/Feature/ConsoleExceptionTests/RunScheduledBackupsCommandFailureTest.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\ConsoleExceptionTests;
 
 use Tests\TestCase;
 use App\Models\BackupSchedule;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
-use Carbon\Carbon;
 use App\Exceptions\BackupFailedException;
 use App\Services\DatabaseBackupService;
 use Illuminate\Support\Facades\Notification;
@@ -30,8 +29,8 @@ class RunScheduledBackupsCommandFailureTest extends TestCase
     protected function tearDown(): void
     {
         File::deleteDirectory(storage_path('app/test-backups'));
-        parent::tearDown();
         Mockery::close();
+        parent::tearDown();
     }
 
     public function test_throws_BackupFailedException_and_catches_it()

--- a/tests/Feature/ConsoleTests/AddDBProfileCommandTest.php
+++ b/tests/Feature/ConsoleTests/AddDBProfileCommandTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\ConsoleTests;
 
 use Tests\TestCase;
 use App\Services\ConfigService;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\File;
+use Mockery;
 
 class AddDBProfileCommandTest extends TestCase
 {
@@ -48,6 +49,8 @@ class AddDBProfileCommandTest extends TestCase
         if (File::exists($this->testConfigDir)) {
             File::deleteDirectory($this->testConfigDir);
         }
+
+        Mockery::close();
         parent::tearDown();
     }
 

--- a/tests/Feature/ConsoleTests/BackupDatabaseCommandTest.php
+++ b/tests/Feature/ConsoleTests/BackupDatabaseCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\ConsoleTests;
 
 use Tests\TestCase;
 use App\Models\DatabaseConnection;
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use App\Services\ConfigService;
 use Illuminate\Support\Facades\Crypt;
+use Mockery;
 
 class BackupDatabaseCommandTest extends TestCase
 {
@@ -58,6 +59,8 @@ class BackupDatabaseCommandTest extends TestCase
         if (File::exists($this->testConfigDir)) {
             File::deleteDirectory($this->testConfigDir);
         }
+
+        Mockery::close();
         parent::tearDown();
     }
 

--- a/tests/Feature/ConsoleTests/BackupStatusCommandTest.php
+++ b/tests/Feature/ConsoleTests/BackupStatusCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\ConsoleTests;
 
 use Tests\TestCase;
 use App\Models\BackupJob;

--- a/tests/Feature/ConsoleTests/ListDBProfilesCommandTest.php
+++ b/tests/Feature/ConsoleTests/ListDBProfilesCommandTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\ConsoleTests;
 
 use Tests\TestCase;
 use Illuminate\Support\Facades\File;
 use App\Services\ConfigService;
 use Illuminate\Support\Facades\Crypt;
+use Mockery;
 
 class ListDBProfilesCommandTest extends TestCase
 {
@@ -48,6 +49,8 @@ class ListDBProfilesCommandTest extends TestCase
         if (File::exists($this->testConfigDir)) {
             File::deleteDirectory($this->testConfigDir);
         }
+
+        Mockery::close();
         parent::tearDown();
     }
 

--- a/tests/Feature/ConsoleTests/RemoveDBProfileCommandTest.php
+++ b/tests/Feature/ConsoleTests/RemoveDBProfileCommandTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\ConsoleTests;
 
 use Tests\TestCase;
 use Illuminate\Support\Facades\File;
 use App\Services\ConfigService;
 use Illuminate\Support\Facades\Crypt;
+use Mockery;
 
 class RemoveDBProfileCommandTest extends TestCase
 {
@@ -48,6 +49,8 @@ class RemoveDBProfileCommandTest extends TestCase
         if (File::exists($this->testConfigDir)) {
             File::deleteDirectory($this->testConfigDir);
         }
+
+        Mockery::close();
         parent::tearDown();
     }
 

--- a/tests/Feature/ConsoleTests/RunScheduledBackupsCommandTest.php
+++ b/tests/Feature/ConsoleTests/RunScheduledBackupsCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\ConsoleTests;
 
 use Tests\TestCase;
 use App\Models\BackupSchedule;


### PR DESCRIPTION
just classify test files into folders :APITests, ConsoleTests and ConsoleExcpetionTests.
and to avoid Mocker clean up errors use :
php artisan test --process-isolation
to run each test method in its own separate PHP process.